### PR TITLE
refactor: Clipboard を io.WriteCloser として wrap して io.Writer として扱うようにする

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ var rootCmd = &cobra.Command{
 			return
 		}
 
-		outFileName := createFileName(params.output, params.format, "png")
+		outFileName := createFileName(time.Now(), params.output, params.format, "png")
 		file, err := os.Create(outFileName)
 		if err != nil {
 			fmt.Println("Failed to create file:", err)
@@ -74,15 +74,10 @@ func Execute() {
 
 // createFileName は、ファイル名を作成する
 // extension は、ピリオドなしの拡張子を指定する
-func createFileName(fileName string, format string, extension string) string {
-
-	outFileName := fileName
-
-	now := time.Now()
-	if fileName == "" {
-		// 出力ファイル名が指定されていない場合は、ファイル名を作ってやる
-		outFileName = fmt.Sprintf("%s.%s", now.Format(format), extension)
+func createFileName(now time.Time, fileName string, format string, extension string) string {
+	if fileName != "" {
+		return fileName
 	}
-
-	return outFileName
+	// 出力ファイル名が指定されていない場合は、ファイル名を作ってやる
+	return fmt.Sprintf("%s.%s", now.Format(format), extension)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,19 +18,10 @@ type CommandParameters struct {
 
 var params CommandParameters
 
-// createFileName は、ファイル名を作成する
-// extension は、ピリオドなしの拡張子を指定する
-func createFileName(fileName string, format string, extension string) string {
-
-	outFileName := fileName
-
-	now := time.Now()
-	if fileName == "" {
-		// 出力ファイル名が指定されていない場合は、ファイル名を作ってやる
-		outFileName = fmt.Sprintf("%s.%s", now.Format(format), extension)
-	}
-
-	return outFileName
+func init() {
+	rootCmd.Flags().StringVarP(&params.output, "output", "o", "", "Output file name")
+	rootCmd.Flags().StringVarP(&params.format, "format", "", "20060102_15-04-05", "format of the output file")
+	rootCmd.Flags().BoolVarP(&params.clipboard, "clipboard", "c", false, "Copy to clipboard")
 }
 
 var rootCmd = &cobra.Command{
@@ -81,8 +72,17 @@ func Execute() {
 	}
 }
 
-func init() {
-	rootCmd.Flags().StringVarP(&params.output, "output", "o", "", "Output file name")
-	rootCmd.Flags().StringVarP(&params.format, "format", "", "20060102_15-04-05", "format of the output file")
-	rootCmd.Flags().BoolVarP(&params.clipboard, "clipboard", "c", false, "Copy to clipboard")
+// createFileName は、ファイル名を作成する
+// extension は、ピリオドなしの拡張子を指定する
+func createFileName(fileName string, format string, extension string) string {
+
+	outFileName := fileName
+
+	now := time.Now()
+	if fileName == "" {
+		// 出力ファイル名が指定されていない場合は、ファイル名を作ってやる
+		outFileName = fmt.Sprintf("%s.%s", now.Format(format), extension)
+	}
+
+	return outFileName
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_createFileName(t *testing.T) {
+	type args struct {
+		now     time.Time
+		outFile string
+		format  string
+		ext     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test with default values",
+			args: args{
+				now:     time.Date(2025, 5, 11, 0, 0, 0, 0, time.UTC),
+				outFile: "",
+				format:  "20060102_15-04-05",
+				ext:     "png",
+			},
+			want: "20250511_00-00-00.png",
+		},
+		{
+			name: "Test with custom output file name",
+			args: args{
+				now:     time.Date(2025, 5, 11, 0, 0, 0, 0, time.UTC),
+				outFile: "custom_name",
+				format:  "20060102_15-04-05",
+				ext:     "png",
+			},
+			want: "custom_name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createFileName(tt.args.now, tt.args.outFile, tt.args.format, tt.args.ext); got != tt.want {
+				t.Errorf("createFileName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -46,3 +46,38 @@ func Test_createFileName(t *testing.T) {
 		})
 	}
 }
+
+func Test_getWriteCloser(t *testing.T) {
+	type args = getWriterCloserInput
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Test with clipboard",
+			args: args{
+				isClipboard: true,
+				filename:    "",
+			},
+		},
+		{
+			name: "Test with file",
+			args: args{
+				isClipboard: false,
+				filename:    "test.png",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getWriteCloser(tt.args)
+			if err != nil {
+				t.Errorf("getWriteCloser() error = %v", err)
+				return
+			}
+			if got == nil {
+				t.Errorf("getWriteCloser() = nil")
+			}
+		})
+	}
+}

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,28 @@
+package clipboard
+
+import (
+	"io"
+
+	"golang.design/x/clipboard"
+)
+
+type C struct{}
+
+var _ io.WriteCloser = (*C)(nil)
+
+func New() *C {
+	return &C{}
+}
+
+func Init() error {
+	return clipboard.Init()
+}
+
+func (c *C) Write(p []byte) (n int, err error) {
+	clipboard.Write(clipboard.FmtImage, p)
+	return len(p), nil
+}
+
+func (c *C) Close() error {
+	return nil
+}


### PR DESCRIPTION
## 何のため

QRCode ライブラリには`func (q *QRCode) Write(size int, out io.Writer) error` のような関数がある。

https://pkg.go.dev/github.com/skip2/go-qrcode@v0.0.0-20200617195104-da1b6568686e#QRCode.Write

これを使って処理の見通しをよくしたい。

## 何をしたか

clipboard のライブラリを wrap して io.WriteCloser を満たすようにした。

ついでにその他の関数をいい感じに修正してテストを書いた