### PR TITLE
add: RecoveryLevel parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ qrg <text>
 ## Options
 
 - `--format` : Specify the datetime format. The default is the Go format `20060102_150405`.
+- `-l` `--level` : Specify the error correction level. The default is `M`. Available levels are:
+  - `L` `low` `7`: 7% of codewords can be restored.
+  - `M` `medium` `15`: 15% of codewords can be restored.
+  - `Q` `quartile` `25`: 25% of codewords can be restored.
+  - `H` `high` `30`: 30% of codewords can be restored.
 - `-c` `--clipboard` : Save the QR code to the clipboard instead of a file.
 - `-o` `--output` : Specify the output file name. (e.g. `qrg -o qrcode.png "text"`)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -95,13 +96,13 @@ var rootCmd = &cobra.Command{
 func parseRecoveryLevel(level string) (qrcode.RecoveryLevel, error) {
 	level = strings.ToUpper(level)
 	switch level {
-	case "L", "LOW", "7":
+	case "L", "LOW", strconv.Itoa(int(qrcode.Low)), "7":
 		return qrcode.Low, nil
-	case "M", "MEDIUM", "15":
+	case "M", "MEDIUM", strconv.Itoa(int(qrcode.Medium)), "15":
 		return qrcode.Medium, nil
-	case "Q", "QUARTILE", "25":
+	case "Q", "QUARTILE", strconv.Itoa(int(qrcode.High)), "25":
 		return qrcode.High, nil
-	case "H", "HIGHEST", "30":
+	case "H", "HIGHEST", strconv.Itoa(int(qrcode.Highest)), "30":
 		return qrcode.Highest, nil
 	default:
 		return qrcode.Medium, fmt.Errorf("invalid error correction level: %s", level)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var (
 func init() {
 	rootCmd.Flags().StringVarP(&params.output, "output", "o", "", "Output file name")
 	rootCmd.Flags().StringVarP(&params.format, "format", "", "20060102_15-04-05", "format of the output file")
-	rootCmd.Flags().StringVarP(&params.level, "level", "l", "M", "Error Recovery level (L, M, Q, H or 0, 1, 2, 3)")
+	rootCmd.Flags().StringVarP(&params.level, "level", "l", "M", "Error Recovery level (L, M, Q, H or 7, 15, 25, 30)")
 	rootCmd.Flags().BoolVarP(&params.clipboard, "clipboard", "c", false, "Copy to clipboard")
 	rootCmd.Flags().IntVarP(&params.size, "size", "s", 256, "QR code size")
 	rootCmd.Flags().BoolVar(&params.version, "version", false, "Show version information")
@@ -91,17 +91,17 @@ var rootCmd = &cobra.Command{
 }
 
 // parseRecoveryLevel は、文字列からqrcode.RecoveryLevelを解析する
-// 有効なlevelは、L, M, Q, H(大文字・小文字区別なし) または 0, 1, 2, 3
+// 有効なlevelは、L, M, Q, H(大文字・小文字区別なし) または 7, 15, 25, 30
 func parseRecoveryLevel(level string) (qrcode.RecoveryLevel, error) {
 	level = strings.ToUpper(level)
 	switch level {
-	case "L", "LOW", "0":
+	case "L", "LOW", "7":
 		return qrcode.Low, nil
-	case "M", "MEDIUM", "1":
+	case "M", "MEDIUM", "15":
 		return qrcode.Medium, nil
-	case "Q", "QUARTILE", "2":
+	case "Q", "QUARTILE", "25":
 		return qrcode.High, nil
-	case "H", "HIGHEST", "3":
+	case "H", "HIGHEST", "30":
 		return qrcode.Highest, nil
 	default:
 		return qrcode.Medium, fmt.Errorf("invalid error correction level: %s", level)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -91,27 +91,112 @@ func Test_parseRecoveryLevel(t *testing.T) {
 		wantLevel qrcode.RecoveryLevel
 		wantErr   bool
 	}{
-		{"L uppercase", "L", qrcode.Low, false},
-		{"l lowercase", "l", qrcode.Low, false},
-		{"LOW", "Low", qrcode.Low, false},
-		{"7", "7", qrcode.Low, false},
+		{
+			"L uppercase",
+			"L",
+			qrcode.Low,
+			false,
+		},
+		{
+			"l lowercase",
+			"l",
+			qrcode.Low,
+			false,
+		},
+		{
+			"LOW",
+			"Low",
+			qrcode.Low,
+			false,
+		},
+		{
+			"7",
+			"7",
+			qrcode.Low,
+			false,
+		},
 
-		{"M uppercase", "M", qrcode.Medium, false},
-		{"m lowercase", "m", qrcode.Medium, false},
-		{"MEDIUM", "Medium", qrcode.Medium, false},
-		{"15", "15", qrcode.Medium, false},
+		{
+			"M uppercase",
+			"M",
+			qrcode.Medium,
+			false,
+		},
+		{
+			"m lowercase",
+			"m",
+			qrcode.Medium,
+			false,
+		},
+		{
+			"MEDIUM",
+			"Medium",
+			qrcode.Medium,
+			false,
+		},
+		{
+			"15",
+			"15",
+			qrcode.Medium,
+			false,
+		},
 
-		{"Q uppercase", "Q", qrcode.High, false},
-		{"q lowercase", "q", qrcode.High, false},
-		{"QUARTILE", "Quartile", qrcode.High, false},
-		{"25", "25", qrcode.High, false},
+		{
+			"Q uppercase",
+			"Q",
+			qrcode.High,
+			false,
+		},
+		{
+			"q lowercase",
+			"q",
+			qrcode.High,
+			false,
+		},
+		{
+			"QUARTILE",
+			"Quartile",
+			qrcode.High,
+			false,
+		},
+		{
+			"25",
+			"25",
+			qrcode.High,
+			false,
+		},
 
-		{"H uppercase", "H", qrcode.Highest, false},
-		{"h lowercase", "h", qrcode.Highest, false},
-		{"HIGHEST", "Highest", qrcode.Highest, false},
-		{"30", "30", qrcode.Highest, false},
+		{
+			"H uppercase",
+			"H",
+			qrcode.Highest,
+			false,
+		},
+		{
+			"h lowercase",
+			"h",
+			qrcode.Highest,
+			false,
+		},
+		{
+			"HIGHEST",
+			"Highest",
+			qrcode.Highest,
+			false,
+		},
+		{
+			"30",
+			"30",
+			qrcode.Highest,
+			false,
+		},
 
-		{"invalid", "X", qrcode.Medium, true},
+		{
+			"invalid",
+			"X",
+			qrcode.Medium,
+			true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"testing"
 	"time"
+
+	"github.com/skip2/go-qrcode"
 )
 
 func Test_createFileName(t *testing.T) {
@@ -77,6 +79,49 @@ func Test_getWriteCloser(t *testing.T) {
 			}
 			if got == nil {
 				t.Errorf("getWriteCloser() = nil")
+			}
+		})
+	}
+}
+
+func Test_parseRecoveryLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantLevel qrcode.RecoveryLevel
+		wantErr   bool
+	}{
+		{"L uppercase", "L", qrcode.Low, false},
+		{"l lowercase", "l", qrcode.Low, false},
+		{"LOW", "Low", qrcode.Low, false},
+		{"0", "0", qrcode.Low, false},
+
+		{"M uppercase", "M", qrcode.Medium, false},
+		{"m lowercase", "m", qrcode.Medium, false},
+		{"MEDIUM", "Medium", qrcode.Medium, false},
+		{"1", "1", qrcode.Medium, false},
+
+		{"Q uppercase", "Q", qrcode.High, false},
+		{"q lowercase", "q", qrcode.High, false},
+		{"QUARTILE", "Quartile", qrcode.High, false},
+		{"2", "2", qrcode.High, false},
+
+		{"H uppercase", "H", qrcode.Highest, false},
+		{"h lowercase", "h", qrcode.Highest, false},
+		{"HIGHEST", "Highest", qrcode.Highest, false},
+		{"3", "3", qrcode.Highest, false},
+
+		{"invalid", "X", qrcode.Medium, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRecoveryLevel(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseRecoveryLevel(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.wantLevel {
+				t.Errorf("parseRecoveryLevel(%q) = %v, want %v", tt.input, got, tt.wantLevel)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,22 +94,22 @@ func Test_parseRecoveryLevel(t *testing.T) {
 		{"L uppercase", "L", qrcode.Low, false},
 		{"l lowercase", "l", qrcode.Low, false},
 		{"LOW", "Low", qrcode.Low, false},
-		{"0", "0", qrcode.Low, false},
+		{"7", "7", qrcode.Low, false},
 
 		{"M uppercase", "M", qrcode.Medium, false},
 		{"m lowercase", "m", qrcode.Medium, false},
 		{"MEDIUM", "Medium", qrcode.Medium, false},
-		{"1", "1", qrcode.Medium, false},
+		{"15", "15", qrcode.Medium, false},
 
 		{"Q uppercase", "Q", qrcode.High, false},
 		{"q lowercase", "q", qrcode.High, false},
 		{"QUARTILE", "Quartile", qrcode.High, false},
-		{"2", "2", qrcode.High, false},
+		{"25", "25", qrcode.High, false},
 
 		{"H uppercase", "H", qrcode.Highest, false},
 		{"h lowercase", "h", qrcode.Highest, false},
 		{"HIGHEST", "Highest", qrcode.Highest, false},
-		{"3", "3", qrcode.Highest, false},
+		{"30", "30", qrcode.Highest, false},
 
 		{"invalid", "X", qrcode.Medium, true},
 	}


### PR DESCRIPTION
# summary
- added recovery level
  - Accepts string parameters
    - `l` `L` `7` : Low
    - `m` `M` `15` : Middle
    - `q` `Q` `25` : High (Quartile)
    - `h` `H` `30` : Highest
    - ( https://pkg.go.dev/github.com/skip2/go-qrcode#RecoveryLevel )
# commits
- 40c23b52318becd012dfb16060c85556a7a4d939
  - add recovery params 
- c79708d379ea0dba5aed1dee1184ef5c5286d475
  - add test
- 1c73dd5dff61b7dfd745a390842aa619ae15b72d
  - change number to `qrcode.RecoveryLevel`
- 9c457b1e830f843069d68a1c2506ca818396212b
  - add reference of `qrcode.RecoveryLevel`
- aa799d98a8a10037b61abc82df20e4b3be97389a
  - add readme for RecoveryLevel
- 4168afd5fd21173b3dadfca4dcf103210c03d74a
  - expand test case